### PR TITLE
returning the hash from urlBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import { UrlParser } from 'url-params-parser'
 // UrlParser(url, placeholder)
 
 const urlParser = UrlParser(
-  "https://address.com:99/employees/show/1234/developer/reports/asc/?climate=change&sea-level=rising",
+  "https://address.com:99/employees/show/1234/developer/reports/asc/?climate=change&sea-level=rising#danger",
   "/employees/show/:id/:title/reports/:order"
 )
 ```
@@ -115,6 +115,15 @@ Returns an array with all the elements of a pathname
 ```:javascript
 urlParser.pathNames
 // returns [ "employees", "show", "1234", "developer", "reports", "asc" ]
+```
+
+### hash
+
+Wrapper for URL().hash
+
+```:javascript
+urlParser.hash
+// returns "#danger"
 ```
 
 ### host

--- a/url_parser.js
+++ b/url_parser.js
@@ -2,6 +2,14 @@ const UrlParser = (urlString, namedUrl = "") => {
   const urlBase = new URL(urlString);
 
   /**
+   * Wrapper for URL.hash
+   *
+   **/
+  function hash() {
+    return urlBase.hash;
+  }
+
+  /**
    * Wrapper for URL.host
    *
    **/
@@ -169,6 +177,7 @@ const UrlParser = (urlString, namedUrl = "") => {
   }
 
   return Object.freeze({
+    hash: hash(),
     host: host(),
     hostname: hostname(),
     namedParams: namedParams(),


### PR DESCRIPTION
In svelte-router-spa the hash navigation is still not working, partially because the UrlParser did not return the hash without this modification. (the svelte router issue: https://github.com/jorgegorka/svelte-router/issues/80)